### PR TITLE
add iverilog-sim-tests, with testing scripts and instructions

### DIFF
--- a/iverilog-sim-tests/.gitignore
+++ b/iverilog-sim-tests/.gitignore
@@ -1,0 +1,1 @@
+compiled-verilog/

--- a/iverilog-sim-tests/README.md
+++ b/iverilog-sim-tests/README.md
@@ -1,0 +1,49 @@
+# Basic Structure
+
+:warning:
+Note that `src` is symlinked to `../gapl-example/src` for convenience.
+:warning:
+
+Every test is defined by two files:
+    src/NAME.gapl
+    test-drivers/test-NAME.v
+
+The former is the GAPL source, the latter is a bit of hand-written Verilog
+to instantiate one of the GAPL-generated modules, pass some inputs, monitor
+the output, etc. (Recommended to use `$monitor(...)` feature of Verilog, which
+is supported by the `iverilog` simulator.)
+
+The two files above will be used within `runtest`. See file `runtest` for
+configuration options, e.g., path for iverilog.
+
+# Example Usage
+
+Example usage of script `runtest`:
+  $ ./runtest vector-map
+
+This does the following:
+  1. run GAPL on `src/vector-map.gapl`
+  2. output written to `compiled-verilog/vector-map.v`
+  3. run iverilog simulation, using
+     `compiled-verilog/vector-map.v` and `test-drivers/test-vector-map.v`
+
+# Creating Your Own Test
+
+To define and run a new test called FOO:
+  1. create `src/FOO.gapl`
+  2. create `test-drivers/test-FOO.v`
+  3. do ./runtest FOO
+
+# Installing iverilog
+
+Source: https://github.com/steveicarus/iverilog
+Useful guide: https://steveicarus.github.io/iverilog/usage/index.html
+
+The following worked for me (Sam) with no major issues:
+```bash
+$ git clone https://github.com/steveicarus/iverilog
+$ sh autoconf.sh
+$ ./configure --prefix="$HOME/.local"
+$ make
+$ make install  # installs into "$HOME/.local/..." as specified above
+```

--- a/iverilog-sim-tests/README.md
+++ b/iverilog-sim-tests/README.md
@@ -1,12 +1,12 @@
 # Basic Structure
 
-:warning:
-Note that `src` is symlinked to `../gapl-example/src` for convenience.
-:warning:
+:warning: Note that `src` is symlinked to `../gapl-example/src` for convenience. :warning:
 
 Every test is defined by two files:
-    src/NAME.gapl
-    test-drivers/test-NAME.v
+```
+src/NAME.gapl
+test-drivers/test-NAME.v
+```
 
 The former is the GAPL source, the latter is a bit of hand-written Verilog
 to instantiate one of the GAPL-generated modules, pass some inputs, monitor
@@ -14,12 +14,14 @@ the output, etc. (Recommended to use `$monitor(...)` feature of Verilog, which
 is supported by the `iverilog` simulator.)
 
 The two files above will be used within `runtest`. See file `runtest` for
-configuration options, e.g., path for iverilog.
+configuration options, e.g., path for `iverilog`.
 
 # Example Usage
 
 Example usage of script `runtest`:
-  $ ./runtest vector-map
+```
+$ ./runtest vector-map
+```
 
 This does the following:
   1. run GAPL on `src/vector-map.gapl`
@@ -32,7 +34,7 @@ This does the following:
 To define and run a new test called FOO:
   1. create `src/FOO.gapl`
   2. create `test-drivers/test-FOO.v`
-  3. do ./runtest FOO
+  3. do `./runtest FOO`
 
 # Installing iverilog
 
@@ -42,6 +44,7 @@ Useful guide: https://steveicarus.github.io/iverilog/usage/index.html
 The following worked for me (Sam) with no major issues:
 ```bash
 $ git clone https://github.com/steveicarus/iverilog
+$ cd iverilog
 $ sh autoconf.sh
 $ ./configure --prefix="$HOME/.local"
 $ make

--- a/iverilog-sim-tests/gapl
+++ b/iverilog-sim-tests/gapl
@@ -1,0 +1,1 @@
+../compiler/build/install/gapl/bin/gapl

--- a/iverilog-sim-tests/runtest
+++ b/iverilog-sim-tests/runtest
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# ==========================================================
+# can edit the following lines if needed
+
+# iverilog consists of multiple executables
+IVERILOG="$HOME/.local/bin/iverilog"
+VVP="$HOME/.local/bin/vvp"
+
+GAPL_COMPILER="../compiler/build/install/gapl/bin/gapl"
+SRC_DIR="src"
+TEST_MAIN_DIR="test-drivers"
+V_DIR="compiled-verilog"
+
+
+# ==========================================================
+# DO NOT EDIT BELOW HERE
+# filenames are all derived from the gapl example filename
+
+TEST_MAIN="$TEST_MAIN_DIR/test-$@.v"
+GAPL_IN="$SRC_DIR/$@.gapl"
+VERILOG_OUT="$V_DIR/$@.v"
+
+function iverun() {
+  local outfile
+  outfile=$(mktemp /tmp/iverun_out.XXXXXXXXX)
+
+  # Ensure cleanup on script exit or interruption
+  trap 'rm -f "$outfile"' EXIT
+
+  # Run iverilog; abort if it fails
+  if ! $IVERILOG -o "$outfile" "$@"; then
+    rm -f "$outfile"
+    echo "iverilog compilation failed."
+    return 1
+  fi
+
+  # Run the simulation
+  if ! $VVP "$outfile"; then
+    rm -f "$outfile"
+    echo "vvp execution failed."
+    return 1
+  fi
+}
+
+mkdir -p $V_DIR
+./gapl -i $GAPL_IN -o $VERILOG_OUT
+iverun $TEST_MAIN $VERILOG_OUT

--- a/iverilog-sim-tests/src
+++ b/iverilog-sim-tests/src
@@ -1,0 +1,1 @@
+../gapl-example/src

--- a/iverilog-sim-tests/test-drivers/test-vector-map.v
+++ b/iverilog-sim-tests/test-drivers/test-vector-map.v
@@ -15,17 +15,17 @@ module test;
   );
 
   initial
-    $monitor("in  %h\nout %h", in, out);
-    //  $monitor("in  {%d, %d, %d, %d, %d }\nout {%d, %d, %d, %d, %d }",
-    //     in[0*4 +: 4],
-    //     in[1*4 +: 4],
-    //     in[2*4 +: 4],
-    //     in[3*4 +: 4],
-    //     in[4*4 +: 4],
-    //     out[0*4 +: 4],
-    //     out[1*4 +: 4],
-    //     out[2*4 +: 4],
-    //     out[3*4 +: 4],
-    //     out[4*4 +: 4]
-    //  );
+    // $monitor("in  %h\nout %h", in, out);
+    $monitor("in  {%d, %d, %d, %d, %d }\nout {%d, %d, %d, %d, %d }",
+      in[0*4 +: 4],
+      in[1*4 +: 4],
+      in[2*4 +: 4],
+      in[3*4 +: 4],
+      in[4*4 +: 4],
+      out[0*4 +: 4],
+      out[1*4 +: 4],
+      out[2*4 +: 4],
+      out[3*4 +: 4],
+      out[4*4 +: 4]
+    );
 endmodule

--- a/iverilog-sim-tests/test-drivers/test-vector-map.v
+++ b/iverilog-sim-tests/test-drivers/test-vector-map.v
@@ -1,0 +1,31 @@
+module test;
+  wire [19:0] in;
+  wire [19:0] out;
+
+  assign in[0*4 +: 4] = 4'd1;
+  assign in[1*4 +: 4] = 4'd2;
+  assign in[2*4 +: 4] = 4'd3;
+  assign in[3*4 +: 4] = 4'd4;
+  assign in[4*4 +: 4] = 4'd5;
+
+  vector_map_main dut
+  (
+    .i_output(in),
+    .o_input(out)
+  );
+
+  initial
+    $monitor("in  %h\nout %h", in, out);
+    //  $monitor("in  {%d, %d, %d, %d, %d }\nout {%d, %d, %d, %d, %d }",
+    //     in[0*4 +: 4],
+    //     in[1*4 +: 4],
+    //     in[2*4 +: 4],
+    //     in[3*4 +: 4],
+    //     in[4*4 +: 4],
+    //     out[0*4 +: 4],
+    //     out[1*4 +: 4],
+    //     out[2*4 +: 4],
+    //     out[3*4 +: 4],
+    //     out[4*4 +: 4]
+    //  );
+endmodule


### PR DESCRIPTION
Will need to install [`iverilog`](https://github.com/steveicarus/iverilog). See `iverilog-sim-tests/README.md` for installation instructions, and also instructions for using this testing framework.

If you have `iverilog` installed, here's a small example, running `gapl-example/src/vector-map.gapl` with the input `1,2,3,4,5`:
```
$ cd iverilog-sim-tests
$ ./runtest vector-map
in  { 1,  2,  3,  4,  5 }
out { 2,  4,  6,  8, 10 }
```